### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/git-backup-ivy.el
+++ b/git-backup-ivy.el
@@ -28,6 +28,8 @@
 ;;; Code:
 (require 'ivy)
 (require 'git-backup)
+(require 'seq)
+(require 'diff)
 
 (defgroup git-backup-ivy nil
   "Interface to backup system git-backup using ivy."


### PR DESCRIPTION
```
git-backup-ivy.el:143:1:Warning: the following functions are not known to be defined: seq-find,
    diff-no-select
```